### PR TITLE
Use separate fields for in/out extensions

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -88,7 +88,8 @@ type Config struct {
 	Header http.Header
 
 	// WebSocket extensions.
-	Extensions []string
+	InboundExtensions  []string
+	OutboundExtensions []string
 
 	handshakeData map[string]string
 }


### PR DESCRIPTION
This way the server will send back extensions only if the user
code explicitly handles them.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/goxnet/2)

<!-- Reviewable:end -->
